### PR TITLE
add class when embedding SVG file

### DIFF
--- a/static/grunticon.embed.js
+++ b/static/grunticon.embed.js
@@ -87,7 +87,7 @@
 			// take the svg markup and embed it into the selected elements
 			for( i = 0; i < filteredElems.length; i++ ){
 				filteredElems[ i ].innerHTML = icons[ iconName ];
-				filteredElems[ i ].style.backgroundImage = "none";
+				filteredElems[ i ].classList.add("hasEmbeddedSVG");
 				filteredElems[ i ].removeAttribute( embedAttr );
 			}
 		}


### PR DESCRIPTION
IMHO background image should only be removed by CSS (we might even want both background and embedded SVG). Since we need to remove the data-grunticon-embed, I would suggest to change `.style.backgroundImage = "none";` with `.classList.add("hasEmbeddedSVG");`. Then, if you really need to hide background image, just add a rule in your CSS where `.hasEmbeddedSVG { background-image = none }`
