### PR TITLE
Add "before" option to configure a specific location where injecting the stylesheet

### DIFF
--- a/static/grunticon.loader.js
+++ b/static/grunticon.loader.js
@@ -2,7 +2,7 @@
 /*global onloadCSS:true*/
 
 (function(window){
-	var grunticon = function( css, onload ){
+	var grunticon = function( css, onload, before ){
 		"use strict";
 		// expects a css array with 3 items representing CSS paths to datasvg, datapng, urlpng
 		if( !css || css.length !== 3 ){
@@ -37,7 +37,7 @@
 			}
 
 			grunticon.href = href;
-			onloadCSS( loadCSS( href ), onload );
+			onloadCSS( loadCSS( href, before ), onload );
 		};
 
 		img.src = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";

--- a/test/qunit/grunticon_test.js
+++ b/test/qunit/grunticon_test.js
@@ -142,7 +142,7 @@
 	test( 'calling grunticon adds the grunticon class to the html element', function(){
 		expect(1);
 
-		window.grunticon("foo", "bar", "baz");
+		window.grunticon("foo", "bar");
 		ok( document.documentElement.className.match( "grunticon" ) );
 	});
 


### PR DESCRIPTION
Hi,

loadCSS library supports a `before` option to define a specific location where injecting the stylesheet :
https://github.com/filamentgroup/loadCSS/blob/master/src/loadCSS.js#L5

However on Grunticon there is no way to pass this option :
https://github.com/filamentgroup/grunticon-lib/blob/master/static/grunticon.loader.js#L40

What do you think about adding this feature ?

Thank you !

Love all your work btw ;)
