### PR TITLE
Upgrade handlebars to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "directory-encoder": "^0.7.0",
     "fg-loadcss": "^0.1.8",
     "fs-extra": "^0.16.5",
-    "handlebars": "^3.0.0",
+    "handlebars": "^4.0.0",
     "lodash": "^3.5.0",
     "merge-defaults": "^0.2.1",
     "svg-to-png": "^2.0.0",


### PR DESCRIPTION
The changes in handlebar are pretty small-breaking and fixes a vulnerability with an old uglify-js version that handlebars was using. (https://nodesecurity.io/advisories/48)
