### PR TITLE
Fix license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,7 @@
   "bugs": {
     "url": "https://github.com/filamentgroup/grunticon-lib/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/filamentgroup/grunticon-lib/blob/master/LICENSE-MIT"
-    }
-  ],
+  "license": "MIT",
   "main": "lib/grunticon-lib",
   "engines": {
     "node": ">= 0.10.0"


### PR DESCRIPTION
According to the docs, the `licenses` field is deprecated.

https://docs.npmjs.com/files/package.json#license