### PR TITLE
allow config to exclude js and preview.html

### DIFF
--- a/lib/grunticon-helper.js
+++ b/lib/grunticon-helper.js
@@ -9,6 +9,10 @@
 	var imgStats = require( './img-stats' );
 
 	var createPreview = function(src, output, opts){
+
+			if( 'string' !== typeof opts.previewhtml )
+				return;
+
 		var width = opts.defaultWidth,
 				height = opts.defaultHeight,
 				min = opts.min,

--- a/lib/grunticon-lib.js
+++ b/lib/grunticon-lib.js
@@ -130,8 +130,10 @@
 			corsEmbed: config.corsEmbed,
 			logger: logger
 		});
+		if( 'string' == config.loadersnippet ) {
 		fs.writeFileSync( path.join( this.output, config.loadersnippet ), loader );
 		logger.verbose( "grunticon loader file created." );
+		}
 
 		var svgToPngOpts = {
 			defaultWidth: config.defaultWidth,


### PR DESCRIPTION
This is an enhancement request. Currently every time the code fires it generates the preview html and js. I would like to be able to exclude them. This is pretty easy to add without breaking the current setup. Add a conditional check that says if the config parameters aren't a string, skip it. So in your config you could exclude the parameters or override the default example config.
