### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "handlebars": "^3.0.0",
     "lodash": "^3.5.0",
     "merge-defaults": "^0.2.1",
-    "svg-to-png": "^2.0.0",
+    "svg-to-png": "^3.0.0",
     "uglify-js": "^2.4.23",
     "xmldom": "^0.1.19"
   }


### PR DESCRIPTION
Upgraded svg-to-png to ^3.0.0, resolving the phantomjs none pre-built dependency
