### PR TITLE
log svgToPng.convert error

### DIFF
--- a/lib/grunticon-lib.js
+++ b/lib/grunticon-lib.js
@@ -248,7 +248,7 @@
 				logger.ok( "Grunticon processed " + this.files.length + " files." );
 
 				cb();
-			}.bind( this ));
+			}.bind( this ), logger.fatal);
 		}.bind( this ));
 	};
 


### PR DESCRIPTION
At least, for people having their grunticon task stucked when `enhancePNG` option is set to `true`, log the error coming from svg-to-png not able, for example, to find the optipng binary.
(Actually in my case I eventually had to install it from github to get the vendor folder inside it - `npm i -DE imagemin/optipng-bin`)