### PR TITLE
Fix phantomjs dependency error

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "handlebars": "^3.0.0",
     "lodash": "^3.5.0",
     "merge-defaults": "^0.2.1",
-    "svg-to-png": "^2.0.0",
+    "svg-to-png": "^3.1.0",
     "uglify-js": "^2.4.23",
     "xmldom": "^0.1.19"
   }


### PR DESCRIPTION
This bumps the svg-to-png package which fixes this issue: https://github.com/filamentgroup/grunticon/issues/315

With svg-to-png 2.0.0 I get the following error:

```
PHANTOM ERROR: TypeError: undefined is not an object (evaluating 'phantom.args[0]')
TRACE:
 -> phantomjs://code/phantomscript.js: 46
```

… but with 3.1.0 everything seems to work again.
