### PR TITLE
Issue #23

### DIFF
--- a/static/grunticon.embed.js
+++ b/static/grunticon.embed.js
@@ -25,11 +25,18 @@
 		return window.document.querySelector( 'link[href$="'+ href +'"]' );
 	};
 
+	var icons;
+
 	// this function can rip the svg markup from the css so we can embed it anywhere
-	var getIcons = function(stylesheet){
+	var getIcons = function(stylesheet, refresh){
+		if( icons && !refresh ){
+			return icons;
+		}
+
+		icons = {};
+
 		// get grunticon stylesheet by its href
-		var icons = {},
-			svgss,
+		var svgss,
 			rules, cssText,
 			iconClass, iconSVGEncoded, iconSVGRaw;
 

--- a/static/grunticon.embed.js
+++ b/static/grunticon.embed.js
@@ -60,8 +60,15 @@
 
 	// embed an icon of a particular name ("icon-foo") in all elements with that icon class
 	// and remove its background image
-	var embedIcons = function(icons){
-		var selectedElems, filteredElems, embedAttr, selector;
+	var embedIcons = function(iconsOrElement, icons){
+		var parentElem, selectedElems, filteredElems, embedAttr, selector;
+
+		if( !icons ){
+			icons = iconsOrElement;
+			parentElem = document;
+		} else {
+			parentElem = iconsOrElement;
+		}
 
 		// attr to specify svg embedding
 		embedAttr = "data-grunticon-embed";
@@ -71,7 +78,7 @@
 
 			try {
 				// get ALL of the elements matching the selector
-				selectedElems = document.querySelectorAll( selector );
+				selectedElems = parentElem.querySelectorAll( selector );
 			} catch (er) {
 				// continue further with embeds even though it failed for this icon
 				continue;
@@ -102,15 +109,19 @@
 		return filteredElems;
 	};
 
-	var svgLoadedCallback = function(callback){
+	var svgLoadedCallback = function(callbackOrElement, callback){
 		if( grunticon.method !== "svg" ){
 			return;
 		}
 		ready(function(){
-			embedIcons( getIcons( getCSS( grunticon.href ) ) );
+			var icons = getIcons( getCSS( grunticon.href ) );
 
 			if( typeof callback === "function" ){
+				embedIcons( callbackOrElement, icons );
 				callback();
+			} else if ( typeof callbackOrElement === "function" ){
+				embedIcons( icons );
+				callbackOrElement();
 			}
 		});
 	};

--- a/test/qunit/grunticon_test.js
+++ b/test/qunit/grunticon_test.js
@@ -127,6 +127,28 @@
 		equal( icons['grunticon:.icon-bear'], svg, "SVG contents should match" );
 	});
 
+	test( 'getIcons caches icons object results and refreshes', function(){
+		expect(3);
+		var stylesheet = document.createElement( "link" );
+		var href = "files/icons.data.svg.css";
+		stylesheet.href = href;
+		stylesheet.rel = "stylesheet";
+		document.head.appendChild(stylesheet);
+
+		// there is no test property on the icons object
+		var icons = window.grunticon.getIcons( stylesheet );
+		ok( !icons.testPreservedProperty );
+
+		// changes to the object ref are preserved
+		icons.testPreservedProperty = "foo";
+		icons = window.grunticon.getIcons( stylesheet );
+		equal( icons.testPreservedProperty, "foo" );
+
+		// changes to the object ref are gone on refesh
+		icons = window.grunticon.getIcons( stylesheet, true );
+		ok( !icons.testPreservedProperty );
+	});
+
 	test( 'embedIcons embeds an icon', function(){
 		expect(1);
 		var svg = "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"100\" height=\"62.905\"><path d=\"M11.068 34.558c-1.585-2.365-2.595-5.098-2.94-8.106-.343.092-.665.16-1.032.16-2.342 0-4.248-1.905-4.248-4.247 0-1.47.758-2.756 1.883-3.514L16.88 10.4c2.55-1.56 5.534-2.525 8.75-2.64l30.148.092L77.82 4.34v-.345C77.82 1.79 79.585 0 81.79 0c2.206 0 3.997 1.79 3.997 3.995 0 .345-.046.712-.138 1.034l2.042.274c2.365.46 4.156 2.55 4.156 5.052 0 .16 0 .298-.022.436l6.544 3.536c.94.368 1.63 1.31 1.63 2.388 0 .367-.068.69-.206 1.01l-1.63 3.697c-.805 1.31-2.182 2.228-3.79 2.41l-15.04 1.792-13.547 15.902 7.738 13.363 5.098 2.365c.803.552 1.354 1.493 1.354 2.55 0 1.698-1.378 3.077-3.1 3.077l-9.806.022c-2.524 0-4.706-1.424-5.808-3.49L52.88 44.26l-18.92.022 6.682 10.287 4.937 2.25c.918.55 1.515 1.537 1.515 2.663 0 1.7-1.378 3.076-3.077 3.076l-9.828.022c-2.388 0-4.5-1.286-5.65-3.215L19.334 44.74l-6.43 6.246-.527 4.087 2.158 1.423c.368.184.69.438.965.758 1.055 1.332.87 3.284-.46 4.34-.574.482-1.286.713-1.975.69l-4.317.022c-1.194-.14-2.273-.758-2.962-1.677l-5.03-8.68C.277 51.032 0 50 0 48.897c0-1.676.62-3.215 1.676-4.387l9.392-9.952z\"></path></svg>";


### PR DESCRIPTION
Fixes issue #23 

**Don't Merge**

I also added the ability for a user to call `embedSVG` on an optional element in the page instead of the whole page. This is to address the need to reembed after some subtree of the DOM is replaced. We can safely revert that commit if necessary or add tests for it.

