### PR TITLE
Upgrade fs-extra to 0.21.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "directory-colorfy": "^2.1.0",
     "directory-encoder": "^0.9.2",
     "fg-loadcss": "^1.3.1",
-    "fs-extra": "^0.16.5",
+    "fs-extra": "^0.21.0",
     "handlebars": "^3.0.3",
     "lodash": "^3.5.0",
     "merge-defaults": "^0.2.1",


### PR DESCRIPTION
This version upgrades its `graceful-fs` dependency to 4.x which is needed for Node >=7 support.

See npm warning:
> npm WARN deprecated graceful-fs@3.0.5: graceful-fs v3.0.0 and before will fail on node releases >= v 7.0.  Please update to graceful-fs@^4.0.0 as soon as possible. Use 'npm ls graceful-fs' to find it in the tree.