### PR TITLE
Upgrade Handlebars -> 4.0.11 to fix security vulnerability.

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "directory-encoder": "^0.9.2",
     "fg-loadcss": "^1.3.1",
     "fs-extra": "^0.16.5",
-    "handlebars": "^3.0.3",
+    "handlebars": "^4.0.11",
     "lodash": "^3.5.0",
     "merge-defaults": "^0.2.1",
     "svg-to-png": "^3.1.0",


### PR DESCRIPTION
Grunticon is causing security vulnerability warnings in repos of projects using it, due to it's dependency on an older version of Handlebars: 

> The handlebars package before 4.0.0 for Node.js allows remote attackers to conduct cross-site scripting (XSS) attacks...

![screen shot 2018-03-23 at 10 22 49 am](https://user-images.githubusercontent.com/1899920/37836447-d332c98a-2e88-11e8-824d-1b4e3f0caea4.png)

More info about the vulnerability can be found here: 
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-8861 

I've tested locally and Grunticon seems to still do its thing just fine. 